### PR TITLE
Add variable for override of policy template path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,19 @@
 # ansible-iam-role
 
+Associates a single IAM policy with a single IAM role. The role creates the given IAM role if it does not already exist. Policies are generated from templates included within the role unless a full `iam_role_policy_template_path` file path is provided.
+
 # Role Variables
 
-* ```secrets_bucket``` is a required variable.
+Variable | Details
+------------- | -------------
+iam_role_policy_template_path | Path to policy template files. Default empty string value assumes role's templates directory.
+iam_role_name | IAM role name. If the role does not exist it will be created.
+policy_name | Policy name to associate with the IAM role. Also the name of the template file minus file extension used to generate the policy. Template file should have `.json.j2` file extension.
+secrets_bucket  | Required by `*_account_secrets.json` policy templates.
 
 # Usage
 
-```
+```yml
 - name:  Ensure existence of a role
   hosts: localhost
   connection: local
@@ -21,7 +28,15 @@
       tags: always
 
   roles:
-    - { role: ansible-iam-role, iam_role_name: 'myrole', policy_name: 'account_secrets' }
-```
+    # Template included with this role
+    - role: ansible-iam-role
+      iam_role_name: 'myrole'
+      policy_name: 'ro_account_secrets'
+      secrets_bucket: 'client-infrastructure'
 
-```policy_name``` is one of a set of policies that are defined by files in /templates.
+    # Template in the client repo
+    - role: ansible-iam-role
+      iam_role_name: 'myrole'
+      policy_name: 'ro_application_s3'
+      iam_role_policy_template_path: "{{ lookup('env', 'INFRASTRUCTURE_REPO') }}/roles/client-iam/templates"
+```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,1 +1,3 @@
 ---
+
+iam_role_policy_template_path: "" # Default assumes template within this role

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,7 +4,7 @@
 # which is not trivial
 - name: template
   template:
-    src: "{{policy_name}}.json.j2"
+    src: "{{iam_role_policy_template_path}}{{policy_name}}.json.j2"
     dest: "/tmp/{{policy_name}}.json"
 
 - name: ensure role exists


### PR DESCRIPTION
Adds support for policy template files outside of this role. By default templates will still be expected in this role's templates directory.
