### PR TITLE
Required permission for versioned buckets

### DIFF
--- a/templates/ro_account_secrets.json.j2
+++ b/templates/ro_account_secrets.json.j2
@@ -9,6 +9,7 @@
       "Effect": "Allow",
       "Action": [
         "s3:GetObject"
+        "s3:GetObjectVersion",
       ],
       "Resource": ["arn:aws:s3:::{{secrets_bucket}}/*"]
     }


### PR DESCRIPTION
The ansible `s3` module fails without this permission on versioned bucket. Our s3 buckets are versioned by default. 
